### PR TITLE
Per-application tag filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,27 @@ Most inputs are optional, but some of them will only have an effect if they are 
 #### `account_id` (optional - requires `role_to_assume` to be set)
 The id of the account that owns the role `role_to_assume`. If not supplied, the function will simply run using its execution role.
 
-#### `ecr_image_tag_filters` (optional - requires `ecr_repositories` to be set)
-Require that only images tagged with certain tags are included when looking for the most recent image in an ECR repository.
+#### `ecr_applications` (optional)
+An object that describes the ECR repositories containing Docker applications to set versions for, and optionally which image tags to filter on when looking for the most recent Docker image. Example:
+```json
+"ecr_applications": {
+  "my-repo": {},
+  "my-second-repo": {
+    "tag_filters": ["master-branch"]
+  }
+}
+```
 
-#### `ecr_repositories` (optional)
-The names of the ECR repositories containing Docker applications to set versions for.
-
-#### `frontend_names` (optional - requires all `frontend_*` inputs to be set)
-The names of the frontend applications to set versions for.
+#### `frontend_applications` (optional - requires all `frontend_*` inputs to be set)
+An object that describes which frontend applications to set versions for, and optionally which S3 metadata tags to filter on when looking for the most recent S3 artifact. Example:
+```json
+"frontend_applications": {
+  "my-app": {},
+  "my-second-app": {
+    "tag_filters": ["master-branch"]
+  }
+}
+```
 
 #### `frontend_s3_bucket` (optional - requires all `frontend_*` inputs to be set)
 The name of the S3 bucket containing frontend bundles to set versions for.
@@ -47,20 +60,23 @@ The name of the S3 bucket containing frontend bundles to set versions for.
 #### `frontend_s3_prefix` (optional - requires all `frontend_*` inputs to be set)
 The S3 prefix where frontend bundles are stored.
 
-#### `frontend_tag_filters` (optional - requires all `frontend_*` inputs to be set)
-Require that only artifacts that contains specific tags in the user-defined S3 metadata `tags` are included when looking for the most recent artifact.
-
-#### `lambda_names` (optional - requires all `lambda_*` inputs to be set)
+#### `lambda_applications` (optional - requires all `lambda_*` inputs to be set)
 The names of the Lambda functions to set versions for.
+An object that describes which Lambda applications to set versions for, and optionally which S3 metadata tags to filter on when looking for the most recent S3 artifact. Example:
+```json
+"lambda_applications": {
+  "my-app": {},
+  "my-second-app": {
+    "tag_filters": ["master-branch"]
+  }
+}
+```
 
 #### `lambda_s3_bucket` (optional - requires all `lambda_*` inputs to be set)
 The name of the S3 bucket containing Lambda deployment packages to set versions for.
 
 #### `lambda_s3_prefix` (optional - requires all `lambda_*` inputs to be set)
 The S3 prefix where Lambda deployment packages are stored.
-
-#### `lambda_tag_filters` (optional - requires all `lambda_*` inputs to be set)
-Require that only artifacts that contains specific tags in the user-defined S3 metadata `tags` are included when looking for the most recent artifact.
 
 #### `role_to_assume` (optional - requires `account_id` to be set)
 The name of the role to assume. (Note: A policy should be attached to the the Lambda's execution role, exposed as an output in Terraform, that allows it to assume the role).

--- a/README.md
+++ b/README.md
@@ -33,25 +33,31 @@ Most inputs are optional, but some of them will only have an effect if they are 
 The id of the account that owns the role `role_to_assume`. If not supplied, the function will simply run using its execution role.
 
 #### `ecr_applications` (optional)
-An object that describes the ECR repositories containing Docker applications to set versions for, and optionally which image tags to filter on when looking for the most recent Docker image. Example:
+A list that describes the ECR repositories containing Docker applications to set versions for, and optionally which image tags to filter on when looking for the most recent Docker image. Example:
 ```json
-"ecr_applications": {
-  "my-repo": {},
-  "my-second-repo": {
+"ecr_applications": [
+  {
+    "name": "my-repo"
+  },
+  {
+    "name": "my-second-repo",
     "tag_filters": ["master-branch"]
   }
-}
+]
 ```
 
 #### `frontend_applications` (optional - requires all `frontend_*` inputs to be set)
-An object that describes which frontend applications to set versions for, and optionally which S3 metadata tags to filter on when looking for the most recent S3 artifact. Example:
+A list that describes which frontend applications to set versions for, and optionally which S3 metadata tags to filter on when looking for the most recent S3 artifact. Example:
 ```json
-"frontend_applications": {
-  "my-app": {},
-  "my-second-app": {
+"frontend_applications": [
+  {
+    "name": "my-app"
+  },
+  {
+    "name": "my-second-app",
     "tag_filters": ["master-branch"]
   }
-}
+]
 ```
 
 #### `frontend_s3_bucket` (optional - requires all `frontend_*` inputs to be set)
@@ -61,15 +67,17 @@ The name of the S3 bucket containing frontend bundles to set versions for.
 The S3 prefix where frontend bundles are stored.
 
 #### `lambda_applications` (optional - requires all `lambda_*` inputs to be set)
-The names of the Lambda functions to set versions for.
-An object that describes which Lambda applications to set versions for, and optionally which S3 metadata tags to filter on when looking for the most recent S3 artifact. Example:
+A list that describes which Lambda applications to set versions for, and optionally which S3 metadata tags to filter on when looking for the most recent S3 artifact. Example:
 ```json
-"lambda_applications": {
-  "my-app": {},
-  "my-second-app": {
+"lambda_applications": [
+  {
+    "name": "my-app"
+  },
+  {
+    "name": "my-second-app",
     "tag_filters": ["master-branch"]
   }
-}
+]
 ```
 
 #### `lambda_s3_bucket` (optional - requires all `lambda_*` inputs to be set)

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "pipeline_set_version" {
   runtime          = "python3.7"
   filename         = data.archive_file.lambda_src.output_path
   source_code_hash = filebase64sha256(data.archive_file.lambda_src.output_path)
-  timeout          = 20
+  timeout          = var.lambda_timeout
   tags             = var.tags
 }
 

--- a/src/main.py
+++ b/src/main.py
@@ -50,7 +50,7 @@ def assume_role(account_id, account_role):
     return assumedRoleObject["Credentials"]
 
 
-def get_ecr_versions(repo_name_filters=[], image_tag_filters=[]):
+def get_ecr_versions(applications):
     """Gets the latest image version of all ECR repositories in the current account.
 
     Only repositories containing at least one image tagged with `image_tag` and a tag
@@ -58,8 +58,7 @@ def get_ecr_versions(repo_name_filters=[], image_tag_filters=[]):
     of the most recently pushed image.
 
     Args:
-        repo_name_filters: An optional list of names of ECR to filter on (e.g., ["trafficinfo-baseline-micronaut"])
-        image_tag_filters: An optional list of image tags to filter on (e.g., ["master-branch"]).
+        applications: A dictionary of ECR repository names to find versions for (e.g., { "my-ecr-repo": { "tag_filters": ["master-branch"]}, where tag_filters is an optional list of image tags to filter on.
 
     Returns:
         A dictionary containing the names of ECR repositories together with the
@@ -68,10 +67,10 @@ def get_ecr_versions(repo_name_filters=[], image_tag_filters=[]):
 
     client = boto3.client("ecr")
     repositories = client.describe_repositories()["repositories"]
-    if len(repo_name_filters):
+    if len(repositories):
         repositories = list(
             filter(
-                lambda r: r["repositoryName"] in repo_name_filters,
+                lambda r: r["repositoryName"] in applications,
                 repositories,
             )
         )
@@ -79,6 +78,7 @@ def get_ecr_versions(repo_name_filters=[], image_tag_filters=[]):
     versions = {}
     for repo in repositories:
         name = repo["repositoryName"]
+        image_tag_filters = applications[repo].get("tag_filters", [])
         # Only tagged images
         try:
             filter_kwargs = {}
@@ -174,11 +174,10 @@ def update_parameterstore(credentials, name, value, region):
 
 
 def get_s3_artifact_versions(
-    application_names,
+    applications,
     bucket_name,
     s3_prefix,
     allowed_key_patterns=[r"[a-z0-9]{7}\.(zip|jar)$"],
-    artifact_tag_filters=[],
 ):
     """Gets the S3 version of application artifacts stored under a given S3 prefix.
 
@@ -187,12 +186,11 @@ def get_s3_artifact_versions(
     (e.g., `nsbno/trafficinfo-aws/lambdas/<application-name>/<sha1>.zip`).
 
     Args:
-        application_names: The name of the applications to set versions for.
+        applications: A dictionary of S3 artifacts to find versions for (e.g., { "my-s3-artifact": { "tag_filters": ["master-branch"]}, where tag_filters is an optional list of S3 metadata tags to filter artifacts on.
         bucket_name: The name of the S3 bucket to use when looking for application artifacts.
         s3_prefix: The S3 prefix to use when looking for application artifacts
             (e.g., `nsbno/trafficinfo-aws/lambdas`).
         allowed_key_patterns: Allowed S3 key patterns for application artifacts.
-        artifact_tag_filters: An optional list of S3 metadata tags to filter artifacts on (e.g., ["master-branch"]).
 
     Returns:
         A dictionary containing the application names together with the
@@ -202,7 +200,8 @@ def get_s3_artifact_versions(
     s3_resource = boto3.resource("s3")
     versions = {}
 
-    for application_name in application_names:
+    for application_name, details in applications.items():
+        artifact_tag_filters = details.get("tag_filters", [])
         prefix = f"{s3_prefix + '/' if s3_prefix else ''}{application_name}/"
         response = s3.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
         try:
@@ -317,18 +316,24 @@ def lambda_handler(event, context):
     get_versions = event.get("get_versions", True)
     set_versions = event.get("set_versions", True)
 
-    ecr_image_tag_filters = event.get("ecr_image_tag_filters", [])
-    ecr_repositories = event.get("ecr_repositories", [])
+    ecr_applications = event.get("ecr_applications", {}) or {
+        app: {"tag_filters": event.get("ecr_image_tag_filters", [])}
+        for app in event.get("ecr_repositories", [])
+    }  # Fallback to stay backwards compatible
 
-    lambda_names = event.get("lambda_names", [])
-    lambda_tag_filters = event.get("lambda_tag_filters", [])
     lambda_s3_bucket = event.get("lambda_s3_bucket", "")
     lambda_s3_prefix = event.get("lambda_s3_prefix", "")
+    lambda_applications = event.get("lambda_applications", {}) or {
+        app: {"tag_filters": event.get("lambda_tag_filters", [])}
+        for app in event.get("lambda_names", [])
+    }  # Fallback to stay backwards compatible
 
-    frontend_names = event.get("frontend_names", [])
-    frontend_tag_filters = event.get("frontend_tag_filters", [])
     frontend_s3_bucket = event.get("frontend_s3_bucket", "")
     frontend_s3_prefix = event.get("frontend_s3_prefix", "")
+    frontend_applications = event.get("frontend_applications", {}) or {
+        app: {"tag_filters": event.get("frontend_tag_filters", [])}
+        for app in event.get("frontend_names", [])
+    }  # Fallback to stay backwards compatible
 
     role_to_assume = event.get("role_to_assume", "")
     account_id = event.get("account_id", "")
@@ -338,28 +343,24 @@ def lambda_handler(event, context):
     frontend_versions = versions.get("frontend", {})
     lambda_versions = versions.get("lambda", {})
 
-    if get_versions and lambda_s3_bucket and len(lambda_names):
+    if get_versions and lambda_s3_bucket and len(lambda_applications):
         lambda_versions = get_s3_artifact_versions(
-            lambda_names,
+            lambda_applications,
             lambda_s3_bucket,
             lambda_s3_prefix,
             [r"/[a-z0-9]{7,}\.(zip|jar)$"],
-            artifact_tag_filters=lambda_tag_filters,
         )
 
-    if get_versions and frontend_s3_bucket and len(frontend_names):
+    if get_versions and frontend_s3_bucket and len(frontend_applications):
         frontend_versions = get_s3_artifact_versions(
-            frontend_names,
+            frontend_applications,
             frontend_s3_bucket,
             frontend_s3_prefix,
             [r"/[a-z0-9]{7,}\.zip$"],
-            artifact_tag_filters=frontend_tag_filters,
         )
 
-    if get_versions and len(ecr_repositories):
-        ecr_versions = get_ecr_versions(
-            ecr_repositories, ecr_image_tag_filters
-        )
+    if get_versions and len(ecr_applications):
+        ecr_versions = get_ecr_versions(ecr_applications)
 
     if set_versions:
         if len(

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,8 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "lambda_timeout" {
+  description = "The maximum number of seconds the Lambda is allowed to run."
+  default     = 30
+}


### PR DESCRIPTION
This PR adds functionality that allows each application to utilize different sets of tag filters when trying to find the latest artifacts (S3 artifact or Docker image).

In practical terms, this means that application A can have its version defined as the latest artifact from the `master` branch, while application B be versioned by artifacts from a separate branch (e.g., `main`). Previously each artifact store (S3 or ECR) used the same set of filters for all applications in that artifact store, so if one application was bound to the `master` branch, the same filter would apply to all other applications.

The PR keeps backwards compatibility, but the deprecated parameters (`ecr_repositories`, `ecr_image_tag_filters`, `frontend_tag_filters`, `frontend_names`, `lambda_tag_filters`, `lambda_names`) should be removed in the future.